### PR TITLE
adding the presales filter in the backend

### DIFF
--- a/pages/api/presalesHours.js
+++ b/pages/api/presalesHours.js
@@ -19,7 +19,6 @@ export default async (req, res) => {
         // console.log(cron_ids);
         const cron_hours_per_costumer = timesheets.reduce((a,o)=>{
             if(cron_ids.includes(o.user) && o.project.name.toLowerCase().includes('presales')){
-                console.log( o.project.name.toLowerCase() )
                 const groupId = o.project.customer.id;
                 if(a[groupId]) {
                     a[groupId].customerTimeTotalSpend += o.duration;

--- a/pages/api/presalesHours.js
+++ b/pages/api/presalesHours.js
@@ -18,7 +18,8 @@ export default async (req, res) => {
         const cron_ids = cron_users.filter(u=>u.included).map(u=>u.id);
         // console.log(cron_ids);
         const cron_hours_per_costumer = timesheets.reduce((a,o)=>{
-            if(cron_ids.includes(o.user)){
+            if(cron_ids.includes(o.user) && o.project.name.toLowerCase().includes('presales')){
+                console.log( o.project.name.toLowerCase() )
                 const groupId = o.project.customer.id;
                 if(a[groupId]) {
                     a[groupId].customerTimeTotalSpend += o.duration;


### PR DESCRIPTION
This change activates a project filter, so that the presales chart is just showing data from projects with 'presales' in the name.