### PR TITLE
maybe a kimai api change? checking the kimai status code with result.ok

### DIFF
--- a/backend_modules/kimai.js
+++ b/backend_modules/kimai.js
@@ -51,9 +51,9 @@ const postKimai = async (path,body) => {
         retries: 3,
         retryDelay: (attempt, error, response) => Math.pow(2, attempt) * 1000,
     });
+    if (!result.ok) throw new Error('Post to kimai not successful!')
     const json = await result.json();
-    // console.log(json);
-    // console.log("fetchKimai done:",path);
+  
     return json;
 };
 

--- a/pages/api/booking.js
+++ b/pages/api/booking.js
@@ -35,7 +35,6 @@ export default async (req, res) => {
                     //"tags": "pew pow",
                 });
                 console.log("resp",resp);
-                if(resp.code !== 200) throw new Error("Kimai API returned with HTTP status code: "+resp.code);
             }
 
             res.statusCode = 200;


### PR DESCRIPTION
@tilman I changed the http status directly after the fetch function. The response object looks like this: 
```
resp {
  id: 669,
  duration: 1800,
  rate: 0,
  description: 'Test of frontend!',
  fixedRate: null,
  hourlyRate: 0,
  exported: false,
  begin: '2020-06-15T09:00:00+0200',
  end: '2020-06-15T09:30:00+0200',
  activity: 9,
  project: 30,
  user: 24,
  tags: [],
  metaFields: [ { name: 'external', value: null } ]
}
```
I tested it with the current live instance of Kimai.